### PR TITLE
[RNDPOSTGRES-61] pass pgx prepared statements options

### DIFF
--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -152,7 +152,7 @@ func parsePgxOptimizations(cfgMap map[string]any, cfg *pgxpool.Config) error {
 
 		cfg.ConnConfig.DefaultQueryExecMode = defaultQueryExecMode
 	} else {
-		// NOTE: Testing purpouse default query execution mode is "exec".
+		// NOTE: Testing purpose default query execution mode is "exec".
 		// Stroppy aim is to test database performance, not the driver.
 		// So by default pgx's driver level optimizations disabled.
 		// Second potentially useful value is "simple_protocol".

--- a/internal/pool/pool_test.go
+++ b/internal/pool/pool_test.go
@@ -11,21 +11,20 @@ import (
 )
 
 func TestParseConfig_Success(t *testing.T) {
-	params := &stroppy.DriverConfig{
-		Url: "postgres://user:pass@localhost:5432/db",
-		DbSpecific: &stroppy.Value_Struct{
-			Fields: []*stroppy.Value{
-				{Type: &stroppy.Value_String_{String_: "1h"}, Key: "max_conn_lifetime"},
-				{Type: &stroppy.Value_String_{String_: "10m"}, Key: "max_conn_idle_time"},
-				{Type: &stroppy.Value_Int32{Int32: 10}, Key: "max_conns"},
-				{Type: &stroppy.Value_Int32{Int32: 1}, Key: "min_conns"},
-				{Type: &stroppy.Value_Int32{Int32: 2}, Key: "min_idle_conns"},
-				{Type: &stroppy.Value_String_{String_: "info"}, Key: "trace_log_level"},
-			},
-		},
-	}
-
 	t.Run("allConfigured", func(t *testing.T) {
+		params := &stroppy.DriverConfig{
+			Url: "postgres://user:pass@localhost:5432/db",
+			DbSpecific: &stroppy.Value_Struct{
+				Fields: []*stroppy.Value{
+					{Type: &stroppy.Value_String_{String_: "1h"}, Key: "max_conn_lifetime"},
+					{Type: &stroppy.Value_String_{String_: "10m"}, Key: "max_conn_idle_time"},
+					{Type: &stroppy.Value_Int32{Int32: 10}, Key: "max_conns"},
+					{Type: &stroppy.Value_Int32{Int32: 1}, Key: "min_conns"},
+					{Type: &stroppy.Value_Int32{Int32: 2}, Key: "min_idle_conns"},
+					{Type: &stroppy.Value_String_{String_: "info"}, Key: "trace_log_level"},
+				},
+			},
+		}
 		cfg, err := parseConfig(params, logger.Global())
 		require.NoError(t, err)
 		require.Equal(t, "postgres://user:pass@localhost:5432/db", cfg.ConnString())
@@ -37,17 +36,15 @@ func TestParseConfig_Success(t *testing.T) {
 	})
 
 	t.Run("statementCache", func(t *testing.T) {
-		params := params
-		params.DbSpecific.Fields = append(params.DbSpecific.Fields,
-			&stroppy.Value{
-				Type: &stroppy.Value_String_{String_: "cache_statement"},
-				Key:  "default_query_exec_mode",
+		params := &stroppy.DriverConfig{
+			Url: "postgres://user:pass@localhost:5432/db",
+			DbSpecific: &stroppy.Value_Struct{
+				Fields: []*stroppy.Value{
+					{Type: &stroppy.Value_String_{String_: "cache_statement"}, Key: "default_query_exec_mode"},
+					{Type: &stroppy.Value_Int32{Int32: 1000}, Key: "statement_cache_capacity"},
+				},
 			},
-			&stroppy.Value{
-				Type: &stroppy.Value_Int32{Int32: 1000},
-				Key:  "statement_cache_capacity",
-			},
-		)
+		}
 		cfg, err := parseConfig(params, logger.Global())
 		require.NoError(t, err)
 		require.Equal(t, 1000, cfg.ConnConfig.StatementCacheCapacity)


### PR DESCRIPTION
**Allows adding new options to `DriverConfig.db_specific`:**

```
"default_query_exec_mode": "cache_statement" | "cache_describe" | "describe_exec" | "exec" | "simple_protocol"
"description_cache_capacity": int32
"statement_cache_capacity": int32
```

Defaults to `exec`  (no prepared statements and other caches) but still uses the efficient extended binary protocol with pgx.
